### PR TITLE
Datetime parsing UTC

### DIFF
--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -11,6 +11,11 @@ DateTime? parseDateTime(dateString) {
 
 DateTime? _parseRfc822DateTime(String dateString) {
   try {
+    var utc = false;
+    if (dateString.contains(RegExp(r'(GMT|[+-]0{2}(0{2})?)'))) {
+      utc = true;
+    }
+
     var pattern = rfc822DateOnlyPattern;
     if (dateString.contains(RegExp(r'(0?[1-9]|1[0-2]):[0-5][0-9]:[0-5][0-9]'))) {
       pattern = rfc822DatePattern;
@@ -18,8 +23,8 @@ DateTime? _parseRfc822DateTime(String dateString) {
       pattern = rfc822DateWithoutSecondsPattern;
     }
 
-    final format = DateFormat(pattern, 'en_US');
-    return format.parse(dateString);
+    final format = DateFormat(pattern);
+    return format.parse(dateString, utc);
   } on FormatException {
     return null;
   }


### PR DESCRIPTION
Adds a check if a date string contains 'GMT', '+/-00' or '+/-0000' and sets the `isUtc` boolean based on this