### PR TITLE
Release/0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## [0.7.2](https://pub.dev/packages/webfeed-revised/versions/0.7.2)
+## [0.8.0](https://pub.dev/packages/webfeed_revised/versions/0.8.0)
+- Upgrade to Dart 3.0
+- Upgrade xml: ^6.5.0
+- Upgrade intl: ^0.19.0 - [Thanks to @bugrevealingbme](https://github.com/Peterkrol12/webfeed-revised/pull/10)
+- Force RFC822 datetime to be parsed with `en_US` locale - [Thanks to @bbo76](https://github.com/Peterkrol12/webfeed-revised/pull/9)
+
+## [0.7.3-beta](https://pub.dev/packages/webfeed_revised/versions/0.7.3-beta.1)
+- Fixed html parser function
+- Adds the ability to automatically parse and replace HTML tags from some elements of the RSS feed
+
+## [0.7.2](https://pub.dev/packages/webfeed_revised/versions/0.7.2)
 - Applied dart format
 
-## [0.7.1](https://pub.dev/packages/webfeed-revised/versions/0.7.1)
+## [0.7.1](https://pub.dev/packages/webfeed_revised/versions/0.7.1)
 - Updated dependencies
 - Fixed RssItem pubDate optional seconds
 - Added RssItem pubDate UTC parser

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebFeed Revised
 
-[![Pub](https://img.shields.io/pub/v/webfeed_revised.svg)](https://pub.dev/packages/webfeed-revised)
+[![Pub](https://img.shields.io/pub/v/webfeed_revised.svg)](https://pub.dev/packages/webfeed_revised)
 
 A dart package for parsing RSS and Atom feed.
 
@@ -20,7 +20,7 @@ Forked from [WebFeed - V0.7.0](https://pub.dev/packages/webfeed) and improved up
 
 Add this line into your `pubspec.yaml`
 ```
-webfeed_revised: ^0.7.2
+webfeed_revised: ^0.8.0
 ```
 
 Import the package into your dart code using:

--- a/lib/util/datetime.dart
+++ b/lib/util/datetime.dart
@@ -30,8 +30,9 @@ DateTime? _parseRfc822DateTime(String dateString) {
       pattern = rfc822DateWithoutSecondsPattern;
     }
 
-    //force locale to en_US because EEE always en_US and cannot be parsed in other locales
-    final format = DateFormat(pattern,'en_US');
+    // force locale to en_US because EEE always en_US and cannot be parsed in
+    // other locales
+    final format = DateFormat(pattern, 'en_US');
     return format.parse(dateString, utc);
   } on FormatException {
     return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: webfeed_revised
-version: 0.7.2
+version: 0.8.0
 description: webfeed-revised is a dart package for parsing RSS and Atom feeds. Media, DublinCore, iTunes, Syndication namespaces are also supported.
 homepage: https://github.com/Peterkrol12/webfeed-revised
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: ^3.0.0
 dependencies:
   intl: ^0.19.0
-  xml: ^6.2.2
+  xml: ^6.5.0
 dev_dependencies:
-  austerity: ^1.0.0
-  http: ^0.13.5
-  test: ^1.24.1
+  austerity: ^1.2.0
+  http: ^1.2.1
+  test: ^1.25.8

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -373,7 +373,7 @@ void main() {
     expect(
       {
         feed.itunes!.categories![0].category,
-        feed.itunes!.categories![1].category
+        feed.itunes!.categories![1].category,
       },
       ['Technology', 'Foo'],
     );


### PR DESCRIPTION
Contains the following changes:
- Updated dependencies
- Fixed parsing of datetime with `en_US` locale