### PR TITLE
Added support to intl ^0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.9.0](https://pub.dev/packages/webfeed_revised/versions/0.9.0)
+- Upgrade intl: ^0.20.0
+
 ## [0.8.0](https://pub.dev/packages/webfeed_revised/versions/0.8.0)
 - Upgrade to Dart 3.0
 - Upgrade xml: ^6.5.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Forked from [WebFeed - V0.7.0](https://pub.dev/packages/webfeed) and improved up
 
 Add this line into your `pubspec.yaml`
 ```
-webfeed_revised: ^0.8.0
+webfeed_revised: ^0.9.0
 ```
 
 Import the package into your dart code using:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: webfeed_revised
-version: 0.8.0
+version: 0.9.0
 description: webfeed-revised is a dart package for parsing RSS and Atom feeds. Media, DublinCore, iTunes, Syndication namespaces are also supported.
 homepage: https://github.com/Peterkrol12/webfeed-revised
 environment:
   sdk: ^3.0.0
 dependencies:
-  intl: ^0.19.0
+  intl: ^0.20.0
   xml: ^6.5.0
 dev_dependencies:
   austerity: ^1.2.0


### PR DESCRIPTION
Not so much to say except that webfeed_revised is not compatible with newer versions of Flutter like 3.32.x, so I took the chance to bump intl version to ^0.20.0 and raise the webfeed_revised version to an higher version.

Thanks for your work!